### PR TITLE
Fix typos and improve tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ big generate-html -i presentation.md -o presentation.html --css style.css --js n
 ### 2. Generate Slides from HTML
 
 ```bash
-big generate-slides -i presentation.html -o slides_directory [--base-name slide] [--format png] [--width 1280] [--height 720]
+big generate-slides -i presentation.html -o slides_directory [--base-name slide] [--format png] [--width 1920] [--height 1080]
 ```
 
 #### Options
@@ -89,8 +89,8 @@ big generate-slides -i presentation.html -o slides_directory [--base-name slide]
 - `-o, --output-dir`: Directory to output slide images
 - `--base-name`: Base filename for slides (default: "slide")
 - `--format`: Format for the slide images (default: "png")
-- `--width`: Width of the slides in pixels (default: 1280)
-- `--height`: Height of the slides in pixels (default: 720)
+- `--width`: Width of the slides in pixels (default: 1920)
+- `--height`: Height of the slides in pixels (default: 1080)
 
 #### Example
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -134,12 +134,11 @@ fn parse_frontmatter(content: &str) -> (String, String, String, String) {
             if lines[2].starts_with("% ") {
                 date = lines[2].trim_start_matches("% ").trim().to_string();
 
-                // Find the first empty line after frontmatter
+                // Skip optional blank lines after the frontmatter
                 let mut start_idx = 3;
-                while start_idx < lines.len() && !lines[start_idx].trim().is_empty() {
+                while start_idx < lines.len() && lines[start_idx].trim().is_empty() {
                     start_idx += 1;
                 }
-                start_idx = std::cmp::min(start_idx + 1, lines.len());
 
                 // Return the rest of the content
                 return (title, author, date, lines[start_idx..].join("\n"));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -448,3 +448,23 @@ fn test_slide_with_html_content() {
         "HTML should preserve ul and li tags"
     );
 }
+
+#[test]
+fn test_frontmatter_without_blank_line() {
+    // Frontmatter immediately followed by content
+    let markdown_content = "% Title\n% Author\n% Date\n# Slide 1\n\nContent";
+    let markdown_file = create_temp_markdown_file(markdown_content);
+
+    let result = html::generate_html_without_reload(
+        &markdown_file.path().to_path_buf(),
+        &[],
+        &[],
+        true,
+    );
+
+    assert!(result.is_ok());
+    let html = result.unwrap();
+
+    // Content should not be stripped after the frontmatter
+    assert!(html.contains("<div>Slide 1") && html.contains("Content"));
+}

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -81,7 +81,9 @@ impl Default for WatchConfig {
     }
 }
 
-// Not using this type alias currently, but keeping for future refactoring
+// Not using this type alias currently, but keeping for future refactoring.
+// On non-macOS platforms `FsEventWatcher` is not available, so guard it.
+#[cfg(target_os = "macos")]
 #[allow(dead_code)]
 type WatchDebouncer = Debouncer<notify::FsEventWatcher, notify_debouncer_full::FileIdMap>;
 
@@ -435,7 +437,7 @@ pub fn watch_markdown(config: WatchConfig, app_config: &AppConfig) -> Result<()>
         .watch(&abs_watch_path, RecursiveMode::Recursive)
         .map_err(|e| {
             BigError::WatchError(format!(
-                "Failed to start watching directory: {} about {:?}",
+                "Failed to start watching directory: {} at {:?}",
                 e,
                 [abs_watch_path]
             ))

--- a/tests/generate_pptx_test.rs
+++ b/tests/generate_pptx_test.rs
@@ -2,6 +2,7 @@ use image::{ImageBuffer, Rgb};
 use std::fs;
 use std::process::{Command, Output};
 use tempfile::TempDir;
+use zip::ZipArchive;
 
 fn run_command(args: &[&str]) -> Output {
     Command::new("cargo")
@@ -60,4 +61,21 @@ fn test_generate_pptx_command() {
     // Check file size is not zero (very basic check)
     let metadata = fs::metadata(&output_path).expect("Failed to get file metadata");
     assert!(metadata.len() > 0, "PPTX file is empty");
+
+    // Verify slide files within the PPTX archive
+    let file = fs::File::open(&output_path).expect("Failed to open PPTX file");
+    let mut archive = ZipArchive::new(file).expect("Failed to read PPTX as ZIP");
+    let slide_files: Vec<String> = (0..archive.len())
+        .filter_map(|i| {
+            archive
+                .by_index(i)
+                .ok()
+                .map(|f| f.name().to_string())
+        })
+        .filter(|name| name.starts_with("ppt/slides/slide") && name.ends_with(".xml"))
+        .collect();
+
+    assert_eq!(slide_files.len(), 2, "Expected exactly two slide XML files");
+    assert!(slide_files.contains(&"ppt/slides/slide1.xml".to_string()));
+    assert!(slide_files.contains(&"ppt/slides/slide2.xml".to_string()));
 }


### PR DESCRIPTION
## Summary
- correct width/height defaults in README
- handle missing blank line in front matter parsing
- fix watch error message wording and platform cfg
- add regression test for front matter without blank line
- validate slide files when generating PPTX

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684447df41e883209c5adc305bb264fe